### PR TITLE
Check for cssFileNames before mapping over them

### DIFF
--- a/src/templates/html-template.ts
+++ b/src/templates/html-template.ts
@@ -19,9 +19,9 @@ export const htmlTemplate = ({
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>${displayName}</title>
     <script>${injectRequire}</script>
-    ${cssFileNames
+    ${cssFileNames ? cssFileNames
       .map((file) => `<link rel="stylesheet" href="..${file}">`)
-      .join("\n\t\t")}
+      .join("\n\t\t") : ``}
     </head>
     <body>
       <div id="root"></div>


### PR DESCRIPTION
When adding the [Svelte template for `bolt-cep`](https://github.com/hyperbrew/bolt-cep/pull/25) I ran into an error if the Svelte app didn't produce any CSS. Not sure how likely this would be, but this should fix this error.