### PR TITLE
Add CEF command flag to fix React Spectrum undetected clicks

### DIFF
--- a/src/cep-config.ts
+++ b/src/cep-config.ts
@@ -38,6 +38,7 @@ type CEF_Command =
   | "--disable-javascript-open-windows"
   | "--disable-javascript-close-windows"
   | "--disable-javascript-access-clipboard"
+  | "--disable-site-isolation-trials"
   | "--enable-caret-browsing"
   | "--proxy-auto-detect"
   | "--user-agent"


### PR DESCRIPTION
See https://github.com/Adobe-CEP/CEP-Resources/issues/401#issuecomment-2015717136

This click insensibility for the [Adobe React Spectrum](https://react-spectrum.adobe.com/react-spectrum/) could be reported as a known issue within the Bolt CEP framework.