### PR TITLE
fix: 'use strict' newline causes mismatching sourcemap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,7 @@ export const cep = (opts: CepOptions) => {
       });
       newCode = newCode.replace(
         `"use strict"`,
-        `"use strict"\rif (typeof exports === 'undefined') { var exports = {}; }`
+        `"use strict";var exports = typeof exports === "undefined" ? {} : exports;`
       );
       opts.bundle[jsName].code = newCode;
 


### PR DESCRIPTION
The new line created by the ´use strict´ replacement is making the minified code throw errors with line trace pointing to an offset of one `11:20` instead of `10:20`, breaking the sourcemap (sourcemap is generated by default before this plugin changes the minified code).