### PR TITLE
FIX: config.build.outDir resolves to 'dummy-non-existing-folder' while using Vitest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,25 @@ export const cep = (opts: CepOptions) => {
           //@ts-ignore
           const filePath = config.build.rollupOptions.input[key];
           const relativePath = path.relative(config.root, filePath);
-          const destPath = path.resolve(config.build.outDir, relativePath);
+          
+          const standardPath = ''
+          
+          const folderFix = (folder: string) => {
+            console.log('folder fix triggered.')
+            const dummy = 'dummy-non-existing-folder';
+            const defaultDir = 'dist/cep/';
+            if (folder == dummy) {
+                console.log('Dummy folder detected.');
+                return 'dist/cep/';
+            }
+            else {
+                console.log('Dummy not detected. returning folder: ' + folder);
+                return folder;
+            }
+        };
+          
+
+          const destPath = path.resolve(folderFix(config.build.outDir), relativePath);
           const panelHtmlFile = {
             type: "asset",
             source: devHtmlTemplate({


### PR DESCRIPTION
## Problem
When I try to run Vitest unit tests I get the error `Error: ENOENT: no such file or directory, open '/Users/Richard/Applications/Git/Extract-FX/dummy-non-existing-folder/main/index.html` from vite-cep-plugin. Of course 'dumm-non-existing-folder' is not an existing folder. When I run the regular dev server I do get a valid path.

According to the stack trace the error occurs in `node_modules/vite-cep-plugin/lib/index.js` at the command `fs.writeFileSync(destPath, panelHtmlFile.source).` If I console log the variables used in this command variable `config.build.outDir` outputs 'dummy-non-existing-folder.' This is not the case when running the regular dev-server.
Somehow during unit tests vite-cep-plugin can't read the outDir variable correctly (also when trying another value using a vitest.config.ts).

## Changes
- For now I added a function that replaces dummy-non-existing-folder with '/dist/cep' (the default dist output path) as a proof of concept that this does resolve the error.

## TO-DO
- Fixing the underlying issue (but I don't know what it could be).

# Diagnostic info
#### Full error
```
CEP Panels Served at:

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: ENOENT: no such file or directory, open '/Users/Richard/Applications/Git/Extract-FX/dummy-non-existing-folder/main/index.html'
    at Object.writeFileSync (node:fs:2344:20)
    at /Users/Richard/Applications/Git/Extract-FX/node_modules/vite-cep-plugin/lib/index.js:223:24
    at Array.map (<anonymous>)
    at configResolved (/Users/Richard/Applications/Git/Extract-FX/node_modules/vite-cep-plugin/lib/index.js:212:63)
    at file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vite/dist/node/chunks/dep-BcnkIxro.js:53287:67
    at Array.map (<anonymous>)
    at resolveConfig (file:///Users/Richaård/Applications/Git/Extract-FX/node_modules/vite/dist/node/chunks/dep-BcnkIxro.js:53287:53)
    at async _createServer (file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vite/dist/node/chunks/dep-BcnkIxro.js:43320:18)
    at async createViteServer (file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vitest/dist/chunks/cli-api.FAAw0S6C.js:9822:18)
    at async createVitest (file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vitest/dist/chunks/cli-api.FAAw0S6C.js:11441:18)
    at async prepareVitest (file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vitest/dist/chunks/cli-api.FAAw0S6C.js:11864:15)
    at async startVitest (file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vitest/dist/chunks/cli-api.FAAw0S6C.js:11793:15)
    at async start (file:///Users/Richard/Applications/Git/Extract-FX/node_modules/vitest/dist/chunks/cac.DPEe9SCx.js:1506:17) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/Richard/Applications/Git/Extract-FX/dummy-non-existing-folder/main/index.html'
}

error Command failed with exit code 1.
```
#### My dependencies.
```
{
  "name": "bolt-cep",
  "version": "0.0.1",
  "type": "module",
  "scripts": {
    "dev": "vite",
    "watch": "tsc && vite build --watch true",
    "build": "rimraf dist/* && tsc -p \"tsconfig-build.json\" && vite build --watch false",
    "zxp": "rimraf dist/* && tsc -p \"tsconfig-build.json\" && cross-env ZXP_PACKAGE=true vite build --watch false",
    "zip": "rimraf dist/* && tsc -p \"tsconfig-build.json\" && cross-env ZIP_PACKAGE=true vite build --watch false",
    "serve": "cross-env SERVE_PANEL=true vite preview",
    "symlink": "cross-env ACTION=symlink vite",
    "delsymlink": "cross-env ACTION=delsymlink vite",
    "test": "vitest"
  },
  "dependencies": {
    "cep-interface": "^0.6.0",
    "uuid": "^11.0.3"
  },
  "devDependencies": {
    "@babel/core": "^7.19.0",
    "@babel/plugin-proposal-class-properties": "^7.16.0",
    "@babel/plugin-proposal-object-rest-spread": "^7.16.0",
    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
    "@babel/plugin-transform-runtime": "^7.16.4",
    "@babel/preset-env": "^7.19.0",
    "@babel/preset-typescript": "^7.16.0",
    "@babel/runtime": "^7.16.3",
    "@rollup/plugin-babel": "^6.0.4",
    "@rollup/plugin-commonjs": "^28.0.1",
    "@rollup/plugin-image": "^3.0.3",
    "@rollup/plugin-json": "^6.1.0",
    "@rollup/plugin-node-resolve": "^15.3.0",
    "@rollup/plugin-replace": "^6.0.1",
    "@sveltejs/vite-plugin-svelte": "^5.0.1",
    "@tsconfig/svelte": "^5.0.4",
    "@types/fs-extra": "^11.0.4",
    "@types/node": "^22.10.0",
    "@types/trusted-types": "^2.0.2",
    "babel-plugin-transform-scss": "^1.1.0",
    "babel-preset-env": "^1.7.0",
    "c8": "^10.1.2",
    "core-js": "3",
    "cross-env": "^7.0.3",
    "fs-extra": "^11.2.0",
    "rimraf": "^6.0.1",
    "rollup": "^4.27.4",
    "rollup-plugin-multi-input": "^1.3.1",
    "rollup-plugin-node-copy": "^1.0.4",
    "rollup-plugin-scss": "^4.0.0",
    "sass": "^1.81.0",
    "svelte": "^5.2.9",
    "svelte-check": "^4.1.0",
    "svelte-preprocess": "^6.0.3",
    "types-for-adobe": "^7.2.0",
    "types-for-adobe-extras": "^0.0.9",
    "typescript": "^5.7.2",
    "vite": "^6.0.1",
    "vite-cep-plugin": "^1.1.12",
    "vite-plugin-version-mark": "^0.1.3",
    "vitest": "^2.1.6",
    "yarn": "^1.22.17"
  },
  "main": "index.js",
  "license": "MIT"
}
```
