### PR TITLE
chore: use cepDist dir for copying files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,7 @@ export const cep = (opts: CepOptions) => {
       // console.log(" BUILD END");
       const root = "./";
       const src = "./src";
-      const dest = path.join(dir, cepDist);
+      const dest = `dist/${cepDist}`;
       const symlink = false;
       const allPackages = unique(packages.concat(foundPackages));
       copyModules({ packages: allPackages, src: root, dest, symlink });

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,7 @@ export const cep = (opts: CepOptions) => {
       // console.log(" BUILD END");
       const root = "./";
       const src = "./src";
-      const dest = "dist/cep";
+      const dest = path.join(dir, cepDist);
       const symlink = false;
       const allPackages = unique(packages.concat(foundPackages));
       copyModules({ packages: allPackages, src: root, dest, symlink });


### PR DESCRIPTION
Hello 👋 

In short this change uses the `cepDist` instead of hardcoding it, so someone can uses their own name. 

Just getting started with Bolt and Adobe CEP, so maybe I'm missing something, but I wanted to rename the dist folder from `dist/cep` to `dist/{anything}`. Changing the cepDist in `vite.config.ts` (and a couple of other lines) changes most of the output, but it still (by default) creates the `dist/cep/node_modules` folders.

Thanks for the Bolt project 🥇 
